### PR TITLE
value値がnullのパターンがある

### DIFF
--- a/jqselectable/jqselectable.js
+++ b/jqselectable/jqselectable.js
@@ -87,7 +87,9 @@
         $body = self.$body,
         $elem = self.$elem;
 
-      value = value.length ? value : 'nodata';
+      if(value === null || !value.length){
+        value = 'nodata';
+      }
 
       self._map();
 


### PR DESCRIPTION
とあるページで入れようとしたら、「戻る」の時に_build()で使われているvalue値がnullのパターンが出てきました。
その場合、lengthプロパティがないのでエラーしてしまいますのでこのように変更してみてはいかがでしょうか？
