### PR TITLE
jQueryオブジェクトから正しくダミーIDを生成できていない

### DIFF
--- a/jqselectable/jqselectable.js
+++ b/jqselectable/jqselectable.js
@@ -51,7 +51,7 @@
       self.has_no_maxheight = typeof document.body.style.maxHeight;
 
       // id
-      self.id = self.elem.id || 'jqs_' + parseInt(Math.random()*1000);
+      self.id = self.$elem.attr('id') || 'jqs_' + parseInt(Math.random()*1000);
       jQselectableIds[self.id] = self;
 
       // id, class


### PR DESCRIPTION
jQueryオブジェクト経由では elem.id ではID参照ができないため、'jqs_' + 乱数 が毎回IDとして設定されてしまいます。id属性をDOMElementでもjQueryObjectでも正しく引けるように修正してみました。

casperjs 等を使ってテストをする際に、ダミー入力のIDが毎回変わってしまってとても困ったことが発端です。
よろしくおねがいします！
